### PR TITLE
Move SLACK_WEBHOOK_URL docs from repo to org level

### DIFF
--- a/txt_root/secrets/gh-org-slack-webhook-url.txt
+++ b/txt_root/secrets/gh-org-slack-webhook-url.txt
@@ -2,9 +2,9 @@ secret-name: SLACK_WEBHOOK_URL
 secret-expire: never
 is-secret: true
 
-secret-updated: 2025-08-14
-secret-updated-by: Tahir
-secret-type: gh-repo
+secret-updated: 2026-05-08
+secret-updated-by: JonJagger
+secret-type: gh-org
 secret-usage: URL to send Slack messages to #cyber-dojo-alerts channel in kosli-internal.slack.com
 
 
@@ -16,6 +16,7 @@ Scroll down to the "Webhook URL" section.
 Click "Regenerate"
 Click "Copy URL"
 
-Go to https://github.com/cyber-dojo/secrets/settings/secrets/actions/SLACK_WEBHOOK_URL
+Go to https://github.com/organizations/cyber-dojo/settings/secrets/actions/SLACK_WEBHOOK_URL
+Click [enter a new value]
 Set the value
-Click [Update secret]
+Click [Save changes]


### PR DESCRIPTION
The secret has been migrated from cyber-dojo/secrets repo scope to the cyber-dojo org scope, so rename the file and update secret-type and the GitHub settings URL accordingly.