### PR TITLE
Shift daily secrets-check from 04:00 to 02:27 UTC

### DIFF
--- a/.github/workflows/check-secrets.yml
+++ b/.github/workflows/check-secrets.yml
@@ -2,8 +2,8 @@ name: Daily Check for new/expiring GitHub secrets
 
 on:
   push:
-  schedule: # At 04:00 every weekday
-    - cron: '0 04 * * 1-5'
+  schedule: # At ~2:30 every weekday
+    - cron: '27 02 * * 1-5'
 
 env:
   KOSLI_ORG: cyber-dojo  # Org name in https://app.kosli.com


### PR DESCRIPTION
Stagger the cron time to reduce load on shared GitHub Actions runners that tend to be busy on the hour.