### PR TITLE
Make secrets compliance a single rego-policy decision

### DIFF
--- a/.github/workflows/check-secrets.yml
+++ b/.github/workflows/check-secrets.yml
@@ -1,12 +1,12 @@
 name: Daily Check for new/expiring GitHub secrets
 
 on:
-  push:
+  #push:
   schedule: # At ~2:30 every weekday
     - cron: '27 02 * * 1-5'
 
 env:
-  KOSLI_ORG: cyber-dojo  # Org name in https://app.kosli.com
+  KOSLI_ORG: ${{ vars.KOSLI_ORG }}  # Org name in https://app.kosli.com
   KOSLI_HOST: ${{ vars.KOSLI_HOST }}
   KOSLI_API_TOKEN: '${{ secrets.KOSLI_API_TOKEN }}'
   KOSLI_FLOW: ${{ vars.KOSLI_SECRETS_FLOW }}
@@ -79,9 +79,13 @@ jobs:
             --github-token=${{ secrets.GITHUB_TOKEN }}
             --name=pull-request
 
+
   check-secrets:
     runs-on: ubuntu-latest
     needs: [setup]
+    env:
+      REGO_POLICY_FILENAME: policies/secrets.rego
+      PARAMS_FILENAME: policies/secrets-params.json
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -135,6 +139,26 @@ jobs:
             --type=secrets
             --name=blended-secrets
             --attestation-data="${BLENDED_FILENAME}"   
+
+      - name: Evaluate trail for decision
+        id: evaluate
+        run: |
+          kosli evaluate trail ${KOSLI_TRAIL} \
+            --policy "${REGO_POLICY_FILENAME}" \
+            --params "@${PARAMS_FILENAME}" \
+            --no-assert \
+            --output json > eval-report.json
+          echo "compliant=$(jq -r '.allow' eval-report.json)" >> "${GITHUB_OUTPUT}"
+          jq --slurpfile params "${PARAMS_FILENAME}" '{params: $params[0], allow: .allow, violations: .violations}' eval-report.json > eval-evidence.json
+
+      - name: Attest SDLC-CTRL-0014 decision
+        run:
+          kosli attest decision
+            --control SDLC-CTRL-0014
+            --compliant=${{ steps.evaluate.outputs.compliant }}
+            --name secrets
+            --user-data eval-evidence.json
+            --attachments "${REGO_POLICY_FILENAME}"
 
       - name: Find the secrets needing attention
         run: |

--- a/.github/workflows/create-custom-attestation.yml
+++ b/.github/workflows/create-custom-attestation.yml
@@ -27,5 +27,4 @@ jobs:
         run:
           kosli create attestation-type secrets
             --description "Existence of secret .txt file, existence of secret in Github, days to expiry"
-            --jq "[.[] | .is_secret == false or (.has_txt_file and .days_to_expiry >= 7 and .has_github_secret and .days_since_update <= (365-7))] | all"
             --schema "./docs/custom-attestation-type-schema.json"

--- a/bin/filter_secrets.py
+++ b/bin/filter_secrets.py
@@ -3,8 +3,23 @@
 import glob, os, sys, json
 from copy import deepcopy
 
-ROTATION_DAYS = 365
-ALERT_WINDOW_DAYS = 30
+
+def load_params():
+    """Load the rotation/alert thresholds from the shared policy params file.
+
+    policies/secrets-params.json is the single source of truth shared with the
+    Rego policy (policies/secrets.rego), so the Kosli compliance verdict and
+    this filter's "needs attention" list are always driven by the same numbers.
+    Resolved relative to this script so it works regardless of the caller's cwd.
+    """
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    params_filename = os.path.join(script_dir, "..", "policies", "secrets-params.json")
+    with open(params_filename, "r") as file:
+        params = json.load(file)
+    return params["rotation_days"], params["alert_window_days"]
+
+
+ROTATION_DAYS, ALERT_WINDOW_DAYS = load_params()
 
 
 def print_help():

--- a/policies/secrets-params.json
+++ b/policies/secrets-params.json
@@ -1,0 +1,5 @@
+{
+  "attestation_name": "blended-secrets",
+  "rotation_days": 365,
+  "alert_window_days": 30
+}

--- a/policies/secrets.rego
+++ b/policies/secrets.rego
@@ -1,0 +1,100 @@
+# Policy for the cyber-dojo "secrets" flow (control SDLC-CTRL-0014).
+#
+# Evaluates the `blended-secrets` custom attestation produced by
+# bin/blend_secrets.py and flags any secret that needs attention, mirroring
+# the logic in bin/filter_secrets.py. A trail is compliant only when the
+# attestation data is present AND every secret is positively verified as fine.
+#
+# Structured per the Kosli guidance on avoiding false positives
+# (https://docs.kosli.com/tutorials/evaluate_trails_with_opa):
+#   1. Fail-safe default: `default allow := false`.
+#   2. Drive `allow` via a POSITIVE assertion, not the absence of violations.
+#      If the attestation is missing/renamed, `secrets` is undefined, the
+#      positive assertion fails to evaluate, and `allow` stays false.
+#   3. `violations` are diagnostics only; they explain a denial, they do not
+#      decide it.
+#
+# Parameters (passed via `kosli evaluate trail --params`, read as data.params):
+#   attestation_name   - name of the custom attestation carrying the blended data
+#   rotation_days      - a github secret should be rotated within this many days
+#   alert_window_days  - warn this many days before expiry / before rotation is due
+package policy
+
+import rego.v1
+
+attestation_name := data.params.attestation_name
+
+# The array of per-secret objects from the blended-secrets attestation.
+secrets := input.trail.compliance_status.attestations_statuses[attestation_name].attestation_data
+
+default allow := false
+
+# Positive assertion: the attestation data must exist AND every secret must be
+# individually verified as needing no attention. If `secrets` is undefined
+# (missing/renamed attestation), `is_array` fails and `allow` stays false.
+allow if {
+	is_array(secrets)
+	every s in secrets {
+		secret_is_fine(s)
+	}
+}
+
+# A non-secret needs no attention.
+secret_is_fine(s) if {
+	s.is_secret == false
+}
+
+# A secret is fine only when it is positively in a well-managed state:
+# it has both a .txt file and a github secret, is not within the expiry alert
+# window, and is not within the rotation alert window.
+secret_is_fine(s) if {
+	s.is_secret == true
+	s.has_txt_file == true
+	s.has_github_secret == true
+	s.days_to_expiry > data.params.alert_window_days
+	s.days_since_update < (data.params.rotation_days - data.params.alert_window_days)
+}
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# violations: diagnostics only (they explain a denial, they do not decide it).
+
+# The named attestation is missing from the trail.
+violations contains msg if {
+	not input.trail.compliance_status.attestations_statuses[attestation_name]
+	msg := sprintf("attestation '%s' is missing from the trail", [attestation_name])
+}
+
+# A github secret with no matching .txt file.
+violations contains msg if {
+	some s in secrets
+	s.is_secret == true
+	s.has_github_secret == true
+	s.has_txt_file == false
+	msg := sprintf("No .txt file: %s/%s/%s", [s.scope, s.repo, s.name])
+}
+
+# A .txt file with no matching github secret.
+violations contains msg if {
+	some s in secrets
+	s.is_secret == true
+	s.has_txt_file == true
+	s.has_github_secret == false
+	msg := sprintf("No GitHub secret: %s/%s/%s", [s.scope, s.repo, s.name])
+}
+
+# Expiring within the alert window.
+violations contains msg if {
+	some s in secrets
+	s.is_secret == true
+	s.days_to_expiry <= data.params.alert_window_days
+	msg := sprintf("Expiring soon (in %d days): %s/%s/%s", [s.days_to_expiry, s.scope, s.repo, s.name])
+}
+
+# A github secret aging past its rotation window.
+violations contains msg if {
+	some s in secrets
+	s.is_secret == true
+	s.has_github_secret == true
+	s.days_since_update >= (data.params.rotation_days - data.params.alert_window_days)
+	msg := sprintf("Rotation due (%d days since update): %s/%s/%s", [s.days_since_update, s.scope, s.repo, s.name])
+}

--- a/test/policy_blended_secrets_missing/expected.eval.json
+++ b/test/policy_blended_secrets_missing/expected.eval.json
@@ -1,0 +1,6 @@
+{
+  "allow": false,
+  "violations": [
+    "attestation 'blended-secrets' is missing from the trail"
+  ]
+}

--- a/test/policy_blended_secrets_missing/input.json
+++ b/test/policy_blended_secrets_missing/input.json
@@ -1,0 +1,12 @@
+{
+  "trail": {
+    "name": "secrets-check-999",
+    "flow": "secrets",
+    "compliance_status": {
+      "attestations_statuses": {
+        "pull-request": { "is_compliant": true, "status": "COMPLETE" },
+        "unit-tests":   { "is_compliant": true, "status": "COMPLETE" }
+      }
+    }
+  }
+}

--- a/test/policy_blended_secrets_present_compliant/expected.eval.json
+++ b/test/policy_blended_secrets_present_compliant/expected.eval.json
@@ -1,0 +1,4 @@
+{
+  "allow": true,
+  "violations": null
+}

--- a/test/policy_blended_secrets_present_compliant/input.json
+++ b/test/policy_blended_secrets_present_compliant/input.json
@@ -1,0 +1,57 @@
+{
+  "trail": {
+    "name": "secrets-check-1000",
+    "flow": "secrets",
+    "compliance_status": {
+      "attestations_statuses": {
+        "pull-request": { "is_compliant": true, "status": "COMPLETE" },
+        "unit-tests":   { "is_compliant": true, "status": "COMPLETE" },
+        "blended-secrets": {
+          "is_compliant": true,
+          "status": "COMPLETE",
+          "attestation_data": [
+            {
+              "name": "KOSLI_API_TOKEN",
+              "repo": "secrets",
+              "scope": "org",
+              "is_secret": true,
+              "has_github_secret": true,
+              "has_txt_file": true,
+              "days_since_update": 17,
+              "days_to_expiry": 300,
+              "expires_at": "2027-04-27",
+              "txt_filename": "txt_root/secrets/gh-org-kosli-api-token.txt",
+              "updated_at": "2026-06-14"
+            },
+            {
+              "name": "SLACK_WEBHOOK_URL",
+              "repo": "differ",
+              "scope": "repo",
+              "is_secret": true,
+              "has_github_secret": true,
+              "has_txt_file": true,
+              "days_since_update": 50,
+              "days_to_expiry": 120,
+              "expires_at": "2026-10-29",
+              "txt_filename": "txt_root/differ/gh-repo-slack-webhook-url.txt",
+              "updated_at": "2026-05-12"
+            },
+            {
+              "name": "PUBLIC_CONFIG_FLAG",
+              "repo": "web",
+              "scope": "repo",
+              "is_secret": false,
+              "has_github_secret": true,
+              "has_txt_file": true,
+              "days_since_update": 400,
+              "days_to_expiry": 5,
+              "expires_at": "2026-07-06",
+              "txt_filename": "txt_root/web/gh-repo-public-config-flag.txt",
+              "updated_at": "2025-05-28"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/test/test_secrets_policy.sh
+++ b/test/test_secrets_policy.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -Eeu
+
+MY_DIR="$(dirname "${BASH_SOURCE[0]}")"
+source "${MY_DIR}/lib.sh"
+
+readonly POLICY="${MY_DIR}/../policies/secrets.rego"
+readonly PARAMS="${MY_DIR}/../policies/secrets-params.json"
+
+setUp()
+{
+  # The policy tests drive the kosli CLI (it embeds the OPA/Rego engine).
+  # The CLI is only installed on the main branch in CI, so skip elsewhere
+  # rather than fail on branch pushes.
+  if ! installed kosli; then
+    startSkipping
+  fi
+}
+
+# Evaluate policies/secrets.rego against a local JSON fixture (no API calls)
+# and leave the normalised {allow, violations} verdict in stdoutF.
+evaluate_input()
+{
+  local -r input_file="${1}"
+  kosli evaluate input \
+    --input-file "${input_file}" \
+    --policy "${POLICY}" \
+    --params "@${PARAMS}" \
+    --no-assert \
+    --output json 2>"${stderrF}" | jq -S '{allow, violations}' >"${stdoutF}"
+}
+
+# A trail whose blended-secrets attestation was never reported must be DENIED
+# (not silently allowed), with a diagnostic naming the missing attestation.
+# Guards the Rego "positive assertion" structure against a regression back to
+# the unsafe `allow if count(violations) == 0` false-positive.
+test_missing_blended_secrets_attestation_is_denied()
+{
+  local -r test_root="${MY_DIR}/policy_blended_secrets_missing"
+  evaluate_input "${test_root}/input.json"
+  assertStdoutEquals "line:${LINENO}" "$(cat "${test_root}/expected.eval.json")"
+  assertStderrEmpty "line:${LINENO}"
+}
+
+# Companion positive case: when the attestation is present and every secret is
+# well-managed (both files, outside both alert windows) the trail is ALLOWED.
+# The non-secret entry has deliberately bad dates to prove is_secret==false is
+# ignored. Ensures the deny test above cannot pass for the wrong reason.
+test_present_and_compliant_attestation_is_allowed()
+{
+  local -r test_root="${MY_DIR}/policy_blended_secrets_present_compliant"
+  evaluate_input "${test_root}/input.json"
+  assertStdoutEquals "line:${LINENO}" "$(cat "${test_root}/expected.eval.json")"
+  assertStderrEmpty "line:${LINENO}"
+}
+
+# Load shUnit2.
+source "${MY_DIR}/shunit2"


### PR DESCRIPTION
  The trail's compliance was decided by a --jq rule baked into the
  `secrets` custom attestation-type, using a 7-day alert window that
  diverged from filter_secrets.py's 30-day window. So the Kosli verdict
  and the "needs attention" list could disagree on the same trail, and a
  missing attestation could still read as compliant.

  Move the decision to policies/secrets.rego, evaluated via
  `kosli evaluate trail` and attested with `kosli attest decision`
  (SDLC-CTRL-0014) as the single compliance authority:

  - Structure the policy per Kosli's false-positive guidance: fail-safe default and `allow` driven by a positive assertion, so a missing or renamed attestation denies rather than silently passing.
  - Single-source the thresholds in policies/secrets-params.json, read by both the policy (data.params) and filter_secrets.py, so they cannot drift. The attestation name is a param too, not hardwired.
  - Drop --jq from the `secrets` attestation-type so it only records data (requires re-registering via the create-custom-attestation dispatch).
  - Add offline policy regression tests (kosli evaluate input) covering deny-on-missing-attestation and allow-when-compliant.

  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>