### PR TITLE
Restore the push trigger on the secrets check

### DIFF
--- a/.github/workflows/check-secrets.yml
+++ b/.github/workflows/check-secrets.yml
@@ -1,7 +1,7 @@
 name: Daily Check for new/expiring GitHub secrets
 
 on:
-  #push:
+  push:
   schedule: # At ~2:30 every weekday
     - cron: '27 02 * * 1-5'
 


### PR DESCRIPTION
  The trigger was turned off so the `secrets` custom attestation type
  could be updated (re-registered without its jq rule) without
  check-secrets running on pushes and attesting against it in the
  meantime. That update is done, so return the workflow to running on
  push.

  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>