### PR TITLE
Record rotation of the two gh-repo check-secrets tokens

### DIFF
--- a/txt_root/secrets/gh-repo-list-all-secrets-cyber-dojo.txt
+++ b/txt_root/secrets/gh-repo-list-all-secrets-cyber-dojo.txt
@@ -1,8 +1,8 @@
 secret-name: LIST_ALL_SECRETS_CYBER_DOJO
-secret-expire: 2026-07-21
+secret-expire: 2026-10-14
 is-secret: true
 
-secret-updated: 2026-04-22
+secret-updated: 2026-06-16
 secret-updated-by: JJ
 secret-type: gh-repo
 secret-usage: Token used to run check-secrets.yml workflow (on daily cron job) to check for new-secrets.

--- a/txt_root/secrets/gh-repo-read-all-repos-cyber-dojo.txt
+++ b/txt_root/secrets/gh-repo-read-all-repos-cyber-dojo.txt
@@ -1,8 +1,8 @@
 secret-name: READ_ALL_REPOS_CYBER_DOJO
-secret-expire: 2026-07-21
+secret-expire: 2026-10-14
 is-secret: true
 
-secret-updated: 2026-04-22
+secret-updated: 2026-06-16
 secret-updated-by: JJ
 secret-type: gh-repo
 secret-usage: Token used to run check-secrets.yml workflow (on daily cron job) to check for new-secrets.


### PR DESCRIPTION
  Both tokens were regenerated on 2026-06-16, so their metadata
  now reflects the new update date and the fresh 2026-10-14 expiry.